### PR TITLE
Fixed payload generation for bulking, included ending newline

### DIFF
--- a/src/ElasticSearch/Bulk.php
+++ b/src/ElasticSearch/Bulk.php
@@ -113,6 +113,6 @@ class Bulk {
 				$payloads[] = json_encode($partial);
 			}
 		}
-		return join("\n", $payloads);
+		return join("\n", $payloads) . "\n";
 	}
 }


### PR DESCRIPTION
No ending newline caused bulking to succeed for all but the last
document in the payload, without throwing an error
